### PR TITLE
Update network.sh

### DIFF
--- a/src/network.sh
+++ b/src/network.sh
@@ -26,6 +26,11 @@ ADD_ERR="Please add the following setting to your container:"
 #  Functions
 # ######################################
 
+if [[ -d /sys/class/net/$VM_NET_TAP ]]; then                                                                        
+    printf 'Lingering infertace will be removed: %s\n' "$VM_NET_TAP"                                                                
+    ip link delete "$VM_NET_TAP"                                                                                    
+fi  
+
 configureDHCP() {
 
   # Create the necessary file structure for /dev/vhost-net


### PR DESCRIPTION
If the VM_NET_TAP is there from a prior container remove it so a new one may be built in its place. Its annoying when doing a docker-compose up and it fails because the old container leaves an interface and this prevents it from halting or looping for an error.